### PR TITLE
set announce to empty array if not present

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,7 +125,7 @@ Discovery.prototype._createTracker = function () {
   if (!self.tracker) return
 
   var torrent = self.torrent
-    ? extend({}, self.torrent)
+    ? extend({ announce: [] }, self.torrent)
     : { infoHash: self.infoHashHex, announce: [] }
 
   if (self.announce) torrent.announce = torrent.announce.concat(self.announce)


### PR DESCRIPTION
This patch prevents torrent-discovery from crashing if there is no `announce` property defined on the torrent object.