### PR TITLE
Fixes initializing without DHT

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,10 +33,14 @@ function Discovery (opts) {
 
   self._dhtTimeout = false
   self._internalDHT = false // is the DHT created internally?
-  self.dht = opts.dht || createDHT()
+  self.dht = opts.dht === false
+    ? false
+    : opts.dht || createDHT()
 
-  reemit(self.dht, self, ['error', 'warning'])
-  self.dht.on('peer', onPeer)
+  if (self.dht) {
+    reemit(self.dht, self, ['error', 'warning'])
+    self.dht.on('peer', onPeer)
+  }
 
   function createDHT () {
     if (typeof DHT !== 'function') return false

--- a/test/basic.js
+++ b/test/basic.js
@@ -30,12 +30,13 @@ test('initialize with default dht', function (t) {
 })
 
 test('initialize without dht', function (t) {
-  t.plan(1)
+  t.plan(2)
   var discovery = new Discovery({
     peerId: hat(160),
     port: 6000,
     dht: false
   })
+  t.equal(discovery.dht, false)
   discovery.stop(function () {
     t.pass()
   })


### PR DESCRIPTION
Currently, a DHT instance is always created on `Discovery`, even when `opts.dht` is false. In WebTorrent, this means that private torrents still establish DHT connections. When I run [this WebTorrent test](https://github.com/feross/webtorrent/blob/master/test/node/download-private-dht.js), I see the following:
```
$ tape test/node/download-private-dht.js
TAP version 13
# private torrent should not use DHT
not ok 1 client announced to dht
  ---
    operator: fail
    at: Torrent.<anonymous> (.../webtorrent/test/node/download-private-dht.js:34:11)
  ...
```

This PR fixes this by simply checking the value of `opts.dht` before trying to create an internal DHT.