### PR TITLE
Provide a way to give extra data on announce to the tracker

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ function Discovery (opts) {
   self.port = opts.port || 0 // torrent port
   self.wrtc = opts.wrtc
   self.intervalMs = opts.intervalMs || (15 * 60 * 1000)
+  self.getAnnounceOpts = opts.getAnnounceOpts
 
   if (!self.peerId) throw new Error('peerId required')
   if (!process.browser && !self.port) throw new Error('port required')
@@ -144,7 +145,8 @@ Discovery.prototype._createTracker = function () {
 
   var trackerOpts = {
     rtcConfig: self.rtcConfig,
-    wrtc: self.wrtc
+    wrtc: self.wrtc,
+    getAnnounceOpts: self.getAnnounceOpts
   }
 
   self.tracker = new Tracker(self.peerId, self.port, torrent, trackerOpts)
@@ -181,4 +183,3 @@ Discovery.prototype._dhtAnnounce = function () {
     return self.intervalMs + Math.floor(Math.random() * self.intervalMs / 5)
   }
 }
-


### PR DESCRIPTION
This PRs is dependent on feross/bittorrent-tracker#107 to provide a callback for the client to get updated params and send it along with the announce message to the tracker.