### PR TITLE
schedule dht reannounce once previous called back

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,7 +170,7 @@ Discovery.prototype._dhtAnnounce = function () {
     scheduleReannounce()
   })
 
-  function scheduleReannounce() {
+  function scheduleReannounce () {
     clearTimeout(self._dhtTimeout)
     self._dhtTimeout = setTimeout(function () {
       self._dhtAnnounce()

--- a/index.js
+++ b/index.js
@@ -30,7 +30,6 @@ function Discovery (opts) {
   self.infoHashBuffer = null
   self.torrent = null
 
-  self._dhtAnnouncing = false
   self._dhtTimeout = false
   self._internalDHT = false // is the DHT created internally?
 
@@ -160,21 +159,23 @@ Discovery.prototype._createTracker = function () {
 
 Discovery.prototype._dhtAnnounce = function () {
   var self = this
-  if (!self.port || !self.infoHash || !self.dht || self._dhtAnnouncing) return
+  if (!self.port || !self.infoHash || !self.dht) return
 
-  self._dhtAnnouncing = true
   self.dht.announce(self.infoHash, self.port, function (err) {
     if (err) self.emit('warning', err)
-    self._dhtAnnouncing = false
 
     debug('dht announce complete')
     self.emit('dhtAnnounce')
+
+    scheduleReannounce()
   })
 
-  clearTimeout(self._dhtTimeout)
-  self._dhtTimeout = setTimeout(function () {
-    self._dhtAnnounce()
-  }, getRandomTimeout())
+  function scheduleReannounce() {
+    clearTimeout(self._dhtTimeout)
+    self._dhtTimeout = setTimeout(function () {
+      self._dhtAnnounce()
+    }, getRandomTimeout())
+  }
 
   // Returns timeout interval, with some random jitter
   function getRandomTimeout () {

--- a/index.js
+++ b/index.js
@@ -164,7 +164,7 @@ Discovery.prototype._dhtAnnounce = function () {
   self.dht.announce(self.infoHash, self.port, function (err) {
     if (err) self.emit('warning', err)
 
-    debug('dht announce complete')
+    debug('dht announce complete, infoHash = ' + self.infoHash)
     self.emit('dhtAnnounce')
 
     scheduleReannounce()


### PR DESCRIPTION
Hi, querying the `_dhtAnnouncing` flag and returning once true, practically cancels the option to keep a torrent re-announced for a long period of time.
Considering the use-case where one wants to seed rare files (e.g. their initial seed) and keep them available for downloading regardless of their availability (or lack of) for a long period of time - this is problematic. 
I here inserted a fix which ensures re-announce will always occur and still will not conflict with the previous one (one announce at a time). This is ensured simply because scheduling a re-announce occurs when the previous has called back.
Of-course, re-announcing can be stopped as before, using `.stop`.