### PR TITLE
only reemit 'error' and 'warning' events for internal DHT

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,6 @@ function Discovery (opts) {
   }
 
   if (self.dht) {
-    reemit(self.dht, self, ['error', 'warning'])
     self.dht.on('peer', onPeer)
   }
 
@@ -58,6 +57,7 @@ function Discovery (opts) {
     if (typeof DHT !== 'function') return false
     self._internalDHT = true
     var dht = new DHT()
+    reemit(dht, self, ['error', 'warning'])
     dht.listen(opts.dhtPort)
     return dht
   }


### PR DESCRIPTION
If the user is passing in their own DHT, then they're responsible for listening to these events.

If we add the listeners even when DHT is passed in, then there will be hundreds of listeners in a client with hundreds of torrents. We don't need to get every 'warning' 100 times.