### PR TITLE
Unlimited listeners

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,8 @@ function Discovery (opts) {
   if (!(self instanceof Discovery)) return new Discovery(opts)
   EventEmitter.call(self)
 
+  self.setMaxListeners(0) /* don't warn on > 10 listeners */
+
   self.peerId = opts.peerId
   self.port = opts.port || 0 // torrent port
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "torrent-discovery",
   "description": "Discover BitTorrent and WebTorrent peers",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "author": {
     "name": "Feross Aboukhadijeh",
     "email": "feross@feross.org",


### PR DESCRIPTION
Fixes a bug in WebTorrent where adding more than 10 torrents prints a memory leak warning

Fixes https://github.com/feross/webtorrent-desktop/issues/161