### PR TITLE
Added peer source to provide as much information as available

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ Destroy and cleanup the DHT and tracker instances.
 
 ### events
 
-### `discovery.on('peer', function (peer) {})`
+### `discovery.on('peer', function (peer, source) {})`
 
-Emitted whenever a new peer is discovered.
+Emitted whenever a new peer is discovered. Source is either 'tracker' or 'dht' based on peer source.
 
 **In node**, `peer` is a string in the form `12:34:56:78:4000`.
 

--- a/index.js
+++ b/index.js
@@ -44,10 +44,10 @@ function Discovery (opts) {
   }
   self._onDHTPeer = function (peer, infoHash) {
     if (infoHash.toString('hex') !== self.infoHash) return
-    self.emit('peer', peer.host + ':' + peer.port)
+    self.emit('peer', peer.host + ':' + peer.port, 'dht')
   }
   self._onTrackerPeer = function (peer) {
-    self.emit('peer', peer)
+    self.emit('peer', peer, 'tracker')
   }
   self._onTrackerAnnounce = function () {
     self.emit('trackerAnnounce')

--- a/test/reuse-dht.js
+++ b/test/reuse-dht.js
@@ -4,7 +4,7 @@ var randombytes = require('randombytes')
 var test = require('tape')
 
 test('re-use dht, verify that peers are filtered', function (t) {
-  t.plan(3)
+  t.plan(5)
   var infoHash1 = randombytes(20)
   var infoHash2 = randombytes(20)
 
@@ -16,14 +16,16 @@ test('re-use dht, verify that peers are filtered', function (t) {
     dht: dht
   })
 
-  discovery.once('peer', function (addr) {
+  discovery.once('peer', function (addr, source) {
     t.equal(addr, '1.2.3.4:8000')
+    t.equal(source, 'dht')
   })
   dht.emit('peer', { host: '1.2.3.4', port: '8000' }, infoHash1)
 
   // Only peers for `infoHash1` should get emitted, none from `infoHash2`
-  discovery.once('peer', function (addr) {
+  discovery.once('peer', function (addr, source) {
     t.equal(addr, '4.5.6.7:8000')
+    t.equal(source, 'dht')
 
     discovery.destroy(function () {
       dht.destroy(function () {


### PR DESCRIPTION
I wanted to know peer sources as I could tell when using tracker and dht libraries independently, but wanted the simplicity of using this one instead. It was unavailable before, and I have added it as well as modified the test to test for its presence.