### PR TITLE
Destroy tracker on next tick, so STOP event has time to be sent

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,7 +125,10 @@ Discovery.prototype.destroy = function (cb) {
     self.tracker.removeListener('peer', self._onTrackerPeer)
     self.tracker.removeListener('update', self._onTrackerAnnounce)
     tasks.push(function (cb) {
-      self.tracker.destroy(cb)
+      process.nextTick(function () {
+        self.tracker.destroy(cb)
+        self.tracker = null // cleanup
+      })
     })
   }
 
@@ -145,7 +148,6 @@ Discovery.prototype.destroy = function (cb) {
 
   // cleanup
   self.dht = null
-  self.tracker = null
   self._announce = null
 }
 


### PR DESCRIPTION
For: https://github.com/feross/bittorrent-tracker/issues/190