### PR TITLE
remove destroy method

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,7 +125,7 @@ Discovery.prototype.destroy = function (cb) {
     self.tracker.removeListener('peer', self._onTrackerPeer)
     self.tracker.removeListener('update', self._onTrackerAnnounce)
     tasks.push(function (cb) {
-      self.tracker.destroy(cb)
+      self.tracker = null;
     })
   }
 


### PR DESCRIPTION
For the sake of sending an EVENT 3 (stop announce), it's best to remove the destroy action.

https://github.com/feross/bittorrent-tracker/pull/193
A cleanup mechanism is already in place and allows time for the tracker to clean up after itself.
